### PR TITLE
Fixes for compilation of better-sqlite through a version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ pom.xml.asc
 /figwheel_server.log
 /tests-compiled/
 /node_modules/
+.rebel_readline_history
+/out
+package-lock.json

--- a/dev/cljs/user.cljs
+++ b/dev/cljs/user.cljs
@@ -1,0 +1,16 @@
+(ns cljs.user
+  (:require
+   [clojure.test :refer [run-tests]]
+   [honeysql.core :as sql]
+   [tests.main-test]))
+
+
+(defn run-tests-sync []
+  (run-tests 'tests.main-test))
+
+
+(defn run-tests []
+  (.nextTick js/process run-tests-sync))
+
+
+(def sql-format sql/format)

--- a/project.clj
+++ b/project.clj
@@ -1,35 +1,45 @@
-(defproject district0x/district-server-db "1.0.3"
+(defproject district0x/district-server-db "1.0.4"
   :description "district0x server module for setting up database connection"
   :url "https://github.com/district0x/district-server-db"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[district0x/district-server-config "1.0.1"]
-                 [honeysql "0.9.2"]
-                 [mount "0.1.11"]
-                 [nilenso/honeysql-postgres "0.2.4" :exclusions [honeysql]]
-                 [org.clojure/clojurescript "1.9.946"]]
+                 [honeysql "0.9.4"]
+                 [mount "0.1.16"]
+                 [nilenso/honeysql-postgres "0.2.5" :exclusions [honeysql]]
+                 [org.clojure/clojurescript "1.10.520"]]
 
-  :npm {:dependencies [[better-sqlite3 "4.0.3"]]
+  :npm {:dependencies [[better-sqlite3 "4.1.4"]]
         :devDependencies [[ws "2.0.1"]]}
 
   :figwheel {:server-port 4678}
 
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+  :clean-targets ^{:protect false} ["tests-compiled" "target"]
+
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
                                   [com.cemerick/piggieback "0.2.2"]
-                                  [figwheel-sidecar "0.5.14"]
+                                  [figwheel-sidecar "0.5.18"]
                                   [org.clojure/tools.nrepl "0.2.13"]]
-                   :plugins [[lein-cljsbuild "1.1.7"]
-                             [lein-figwheel "0.5.14"]
+                   :plugins [[lein-ancient "0.6.15"]
+                             [lein-cljsbuild "1.1.7"]
+                             [lein-figwheel "0.5.18"]
                              [lein-npm "0.6.2"]
-                             [lein-doo "0.1.7"]]
+                             [lein-doo "0.1.11"]]
                    :source-paths ["dev"]}}
 
-  :cljsbuild {:builds [{:id "tests"
-                        :source-paths ["src" "test"]
-                        :figwheel {:on-jsload "tests.runner/-main"}
-                        :compiler {:main "tests.runner"
-                                   :output-to "tests-compiled/run-tests.js"
-                                   :output-dir "tests-compiled"
+  :cljsbuild {:builds [{:id "dev"
+                        :source-paths ["src" "dev" "test"]
+                        :figwheel true
+                        :compiler {:main cljs.user
+                                   :output-to "target/js/compiled/dev.js"
+                                   :output-dir "target/js/compiled/out"
                                    :target :nodejs
                                    :optimizations :none
-                                   :source-map true}}]})
+                                   :source-map true}}
+
+                       {:id "tests"
+                        :source-paths ["src" "test"]
+                        :compiler {:main "tests.runner"
+                                   :output-to "tests-compiled/run-tests.js"
+                                   :target :nodejs
+                                   :optimizations :simple}}]})

--- a/src/district/server/db.cljs
+++ b/src/district/server/db.cljs
@@ -17,7 +17,7 @@
   :stop (stop db))
 
 (def Sqlite3Database (js/require "better-sqlite3"))
-(def *transform-result-keys-fn* (atom nil))
+(def ^:dynamic *transform-result-keys-fn* (atom nil))
 
 (defn start [{:keys [:path :opts :transform-result-keys-fn :sql-name-transform-fn]
               :or {path "db.db"

--- a/test/tests/main_test.cljs
+++ b/test/tests/main_test.cljs
@@ -1,4 +1,4 @@
-(ns tests.all
+(ns tests.main-test
   (:require
     [cljs.test :refer-macros [deftest is testing use-fixtures]]
     [district.server.db :as db :refer [db]]
@@ -16,7 +16,7 @@
 (deftest test-db
   (is (= (str @db) "[object Database]"))
 
-  (is (map? (db/run! {:create-table :my-doggos
+  (is (map? (db/run! {:create-table [:my-doggos]
                       :with-columns [[[:doggo/years :unsigned :integer]
                                       [:doggo/description :varchar]]]})))
 

--- a/test/tests/runner.cljs
+++ b/test/tests/runner.cljs
@@ -2,11 +2,11 @@
   (:require
     [cljs.nodejs :as nodejs]
     [cljs.test :refer [run-tests]]
-    [tests.all]))
+    [tests.main-test]))
 
 (nodejs/enable-util-print!)
 
 (defn -main [& _]
-  (run-tests 'tests.all))
+  (run-tests 'tests.main-test))
 
 (set! *main-cli-fn* -main)


### PR DESCRIPTION
- added :^dynamic to quiet warning about a dynamic type
- reworked figwheel config for development, run tests with `(run-tests)
- setup test runner cljsbuild configuration
- fixed tests
- additional vbumps for development

Fixes #2 